### PR TITLE
Fix retrieval docs formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,7 +64,10 @@ def load_embeddings(documents, user_query):
 def generate_response(retriever, query):
     """Generates a response using retrieval-augmented generation."""
     chain = (
-        {"context": retriever, "question": RunnablePassthrough()}
+        {
+            "context": retriever | format_docs,
+            "question": RunnablePassthrough(),
+        }
         | chat_prompt_template
         | model
         | StrOutputParser()


### PR DESCRIPTION
## Summary
- pipe retrieved documents through `format_docs` before prompting

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685b3d8fe3c083238b70ac9343dca0fc