### PR TITLE
Refine assistant prompt to avoid unsupported answers

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,11 @@ model = ChatOpenAI(model_name=LANGUAGE_MODEL)
 template = (
     "You are a knowledgeable and friendly real estate assistant at Sunrise Realty Group.\n"
     "You help clients with questions about buying, selling, and renting homes.\n"
-    "Use only the following information to answer clearly and professionally:\n"
+    "Use only the information provided in the context to answer clearly and professionally.\n"
+    "If the question cannot be answered from the context or is unrelated to real estate, reply with:"
+    " 'I'm sorry, but I don't have information about that based on the provided materials.'\n"
+    "Do not introduce or reference characters, events, or facts that are not explicitly supported by the context.\n"
+    "Context:\n"
     "{context}"
 )
 system_message_prompt = SystemMessagePromptTemplate.from_template(template)


### PR DESCRIPTION
## Summary
- update the system prompt so responses stay within the provided context and avoid unrelated character details
- add explicit fallback messaging for questions that cannot be answered from the retrieved real-estate documents

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e593e54dc083239bb5c0e0826fa309